### PR TITLE
Fix Xcode 11.4 build

### DIFF
--- a/SpecLeaks.xcodeproj/project.pbxproj
+++ b/SpecLeaks.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		79DFEF472289297F00CF65D5 /* Expectation+Leaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DFEF402289297F00CF65D5 /* Expectation+Leaks.swift */; };
 		79DFEF4822892A8900CF65D5 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79DFEF372288B12E00CF65D5 /* Quick.framework */; };
 		79DFEF4922892A8D00CF65D5 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79DFEF352288B12200CF65D5 /* Nimble.framework */; };
+		8C0FEB06242B5E3A00B72A8A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C0FEB05242B5E3A00B72A8A /* XCTest.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		79DFEF3E2289297F00CF65D5 /* LeakTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeakTest.swift; sourceTree = "<group>"; };
 		79DFEF3F2289297F00CF65D5 /* AnalyzeLeakAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyzeLeakAction.swift; sourceTree = "<group>"; };
 		79DFEF402289297F00CF65D5 /* Expectation+Leaks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Expectation+Leaks.swift"; sourceTree = "<group>"; };
+		8C0FEB05242B5E3A00B72A8A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +55,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				79DFEF4822892A8900CF65D5 /* Quick.framework in Frameworks */,
+				8C0FEB06242B5E3A00B72A8A /* XCTest.framework in Frameworks */,
 				79DFEF4922892A8D00CF65D5 /* Nimble.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -109,6 +112,7 @@
 		79D8370C2288AD7B00A5D942 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8C0FEB05242B5E3A00B72A8A /* XCTest.framework */,
 				79DFEF372288B12E00CF65D5 /* Quick.framework */,
 				79DFEF352288B12200CF65D5 /* Nimble.framework */,
 			);

--- a/SpecLeaks.xcodeproj/project.pbxproj
+++ b/SpecLeaks.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		79DFEF472289297F00CF65D5 /* Expectation+Leaks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DFEF402289297F00CF65D5 /* Expectation+Leaks.swift */; };
 		79DFEF4822892A8900CF65D5 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79DFEF372288B12E00CF65D5 /* Quick.framework */; };
 		79DFEF4922892A8D00CF65D5 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 79DFEF352288B12200CF65D5 /* Nimble.framework */; };
-		8C0FEB06242B5E3A00B72A8A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C0FEB05242B5E3A00B72A8A /* XCTest.framework */; };
+		8C0FEB0B242B6F0700B72A8A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C0FEB0A242B6F0700B72A8A /* XCTest.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,7 +46,7 @@
 		79DFEF3E2289297F00CF65D5 /* LeakTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeakTest.swift; sourceTree = "<group>"; };
 		79DFEF3F2289297F00CF65D5 /* AnalyzeLeakAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyzeLeakAction.swift; sourceTree = "<group>"; };
 		79DFEF402289297F00CF65D5 /* Expectation+Leaks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Expectation+Leaks.swift"; sourceTree = "<group>"; };
-		8C0FEB05242B5E3A00B72A8A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		8C0FEB0A242B6F0700B72A8A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,7 +55,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				79DFEF4822892A8900CF65D5 /* Quick.framework in Frameworks */,
-				8C0FEB06242B5E3A00B72A8A /* XCTest.framework in Frameworks */,
+				8C0FEB0B242B6F0700B72A8A /* XCTest.framework in Frameworks */,
 				79DFEF4922892A8D00CF65D5 /* Nimble.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -112,7 +112,7 @@
 		79D8370C2288AD7B00A5D942 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				8C0FEB05242B5E3A00B72A8A /* XCTest.framework */,
+				8C0FEB0A242B6F0700B72A8A /* XCTest.framework */,
 				79DFEF372288B12E00CF65D5 /* Quick.framework */,
 				79DFEF352288B12200CF65D5 /* Nimble.framework */,
 			);
@@ -406,6 +406,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = SpecLeaks/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -435,6 +436,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				INFOPLIST_FILE = SpecLeaks/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";


### PR DESCRIPTION
The specleaks framework won't build on Xcode 11.4 (iOS platform) without linking XCTest framework.

~**Update**: I am in the process of verifying Xcode 11.3 build right now~